### PR TITLE
Improve removeJsImports util to support namespace imports and renamed local bindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "upgrade": "yarn upgrade",
     "dev": "npm-watch | grep --invert-match nodemon",
-    "build": "babel src -d dist -q && eslint . --fix",
+    "build": "babel src -d dist -q",
     "test": "jest",
     "cover": "jest --coverage",
     "flow": "flow check || true",

--- a/src/utils/remove-js-imports.js
+++ b/src/utils/remove-js-imports.js
@@ -32,21 +32,19 @@ export const removeJsImports = (path: NodePath, code: string) => {
           if (targetPath.node.source.value === obsoletePath.node.source.value) {
             const filtered = targetPath.node.specifiers.filter(specifier => {
               const obsoleteSpecifiers = obsoletePath.node.specifiers;
+              const localName = specifier.local.name;
               const ofSameType = obsoleteSpecifiers.filter(s => {
                 return s.type === specifier.type;
               });
-              if (specifier.type === 'ImportDefaultSpecifier') {
-                const name = specifier.local.name;
-                const match = ofSameType.find(s => name === s.local.name);
-                if (match) remove(path, match.local.name);
-                return !match;
-              } else if (specifier.type === 'ImportSpecifier') {
+              if (specifier.type === 'ImportSpecifier') {
                 const name = specifier.imported.name;
                 const match = ofSameType.find(s => name === s.imported.name);
-                if (match) remove(path, match.local.name);
+                if (match) remove(path, localName);
                 return !match;
+              } else {
+                remove(path, localName);
+                return false;
               }
-              return false;
             });
             if (filtered.length > 0) targetPath.node.specifiers = filtered;
             else targetPath.remove();

--- a/src/utils/remove-js-imports.test.js
+++ b/src/utils/remove-js-imports.test.js
@@ -44,10 +44,10 @@ test('removeJsImports, namespace import', () => {
   expect(generateJs(path).trim()).toEqual('');
 });
 
-test('removeJsImports, ', () => {
-  const path = parseJs(`import c, {b} from 'c';`);
-  removeJsImports(path, `import a, {b} from 'c';`);
-  expect(generateJs(path).trim()).toEqual('');
+test('removeJsImports, no match', () => {
+  const path = parseJs(`import b from 'c';`);
+  removeJsImports(path, `import {b} from 'c';`);
+  expect(generateJs(path).trim()).toEqual(`import b from 'c';`);
 });
 
 test('removeJsImports specifiers', () => {
@@ -77,6 +77,6 @@ test('removeJsImports namespace dependent statements', () => {
       a();
     }`,
   );
-  removeJsImports(path, `import a, {b} from 'c';`);
+  removeJsImports(path, `import * as a from 'c';`);
   expect(generateJs(path).trim()).toEqual('function x(a) {\n  a();\n}');
 });


### PR DESCRIPTION
Previously the removeJsImports utility did not work for namespace imports, and required
default imports to be bound to the same identifier name. Additionally, for specifier imports
it used the input specifier local name rather than the target specifier local name when
removing references. This fixes these issues and adds regression tests.