### PR TITLE
Use babylon instead of @babel/parser for jsx support

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,10 +40,10 @@
     }
   },
   "dependencies": {
-    "@babel/parser": "^7.1.5",
     "@babel/template": "^7.1.2",
     "@babel/traverse": "^7.1.5",
     "@babel/types": "^7.1.5",
+    "babylon": "^6.18.0",
     "execa": "^1.0.0",
     "flow-coverage-report": "^0.6.0",
     "fs-extra": "^7.0.1",

--- a/src/utils/find-files.js
+++ b/src/utils/find-files.js
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 import fs from 'fs';
 import util from 'util';
+import path from 'path';
 
 const stat = util.promisify(fs.stat);
 const readDir = util.promisify(fs.readdir);
@@ -36,7 +37,7 @@ export const findFiles = async (root: string, match: string => boolean) => {
     if (stats.isDirectory()) {
       const children = await readDir(root);
       const searches = children.map(child => {
-        return collect(`${root}/${child}`);
+        return collect(path.join(root, child));
       });
       await Promise.all(searches);
     } else {

--- a/src/utils/parse-js.js
+++ b/src/utils/parse-js.js
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 import traverse from '@babel/traverse';
 import NodePath from '@babel/traverse/lib/path';
-import {parse} from '@babel/parser';
+import {parse} from 'babylon';
 import recast from 'recast';
 
 export type ParserOptions = ?{mode: ?('typescript' | 'flow')};
@@ -39,7 +39,9 @@ export const parseJs = (code: string, options: ParserOptions) => {
     parser: {
       parse(source) {
         return parse(source, {
-          sourceType: 'unambiguous',
+          sourceType: 'module',
+          allowImportExportEverywhere: true,
+          allowReturnOutsideFunction: true,
           plugins: [
             ...typeSystem,
             'jsx',

--- a/src/utils/parse-js.test.js
+++ b/src/utils/parse-js.test.js
@@ -29,5 +29,19 @@ test('parseJs', async () => {
   const code = 'const a = 1;';
   const path = parseJs(code);
   const generated = generateJs(path);
-  expect(generated.trim()).toEqual(code);
+  expect(generated).toEqual(code);
+});
+
+test('parseJs with jsx', async () => {
+  const code = `
+    import React from 'react'; 
+    function Test() {
+      return (
+        <div>Hello World</div>
+      );
+    }
+  `;
+  const path = parseJs(code);
+  const generated = generateJs(path);
+  expect(generated).toEqual(code);
 });


### PR DESCRIPTION
For some reason, @babel/parser does not interop with jsx
nicely in conjunction with recast. Moving to babylon fixes
this issue.