### PR TITLE
Update js file APIs to use globs and respect .gitignores

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ async function run() {
       gitClone('some-scaffold-template.git', state.name);
     }),
     step('customize', async () => {
-      const files = await findFiles('.', f => /src/.test(f));
+      const files = await findFiles('**/*.js', f => /src/.test(f));
       for (const file of files) {
         withTextFile(file, text => text.replace(/{{name}}/g, state.name));
       }
@@ -128,10 +128,10 @@ A stepper error indicates what step failed. It can be used for resuming executio
 ```js
 import {findFiles} from '@dubstep/core';
 
-findFiles = (root: string, filter: string => boolean) => Promise<Array<string>>;
+findFiles = (glob?: string, filter?: string => boolean) => Promise<Array<string>>;
 ```
 
-Resolves to a list of file names that are descendants of `root` and match the condition from the `filter` function.
+Resolves to a list of file names that match `glob` and match the condition from the `filter` function. Respects .gitignore.
 
 ##### moveFile
 
@@ -196,11 +196,11 @@ See the [Babel handbook](https://github.com/jamiebuilds/babel-handbook/blob/mast
 ```js
 import {withJsFiles} from '@dubstep/core';
 
-withJsFiles = (root: string, regexp: RegExp, fn: JsFileMutation) => Promise<void>;
+withJsFiles = (glob: string, fn: JsFileMutation) => Promise<void>;
 type JsFileMutation = NodePath => void;
 ```
 
-Runs `withJsFile` only on files that are descendant of `root` and whose absolute path match `regexp`.
+Runs `withJsFile` only on files that match `glob`. 
 
 See the [Babel handbook](https://github.com/jamiebuilds/babel-handbook/blob/master/translations/en/plugin-handbook.md) for more information on `NodePath`'s API.
 

--- a/docs/migrations/00046.md
+++ b/docs/migrations/00046.md
@@ -1,0 +1,9 @@
+### Update withJSFiles and findFiles to use globbing APIs
+
+```diff
+-withJsFiles('root', /regex/, (path) => {});
++withJsFiles('glob/**/*.js', (path) => {});
+
+-findFiles('dir', (file) => true);
++findFiles('glob/**/*.js', (file) => true);
+```

--- a/src/utils/find-files.js
+++ b/src/utils/find-files.js
@@ -22,29 +22,15 @@ THE SOFTWARE.
 @flow
 */
 
-import fs from 'fs';
-import util from 'util';
-import path from 'path';
+import globby from 'globby';
 
-const stat = util.promisify(fs.stat);
-const readDir = util.promisify(fs.readdir);
-
-export const findFiles = async (root: string, match: string => boolean) => {
-  const files = [];
-
-  async function collect(root) {
-    const stats = await stat(root);
-    if (stats.isDirectory()) {
-      const children = await readDir(root);
-      const searches = children.map(child => {
-        return collect(path.join(root, child));
-      });
-      await Promise.all(searches);
-    } else {
-      if (match(root)) files.push(root);
-    }
-  }
-  await collect(root);
-
-  return files;
+export const findFiles = async (
+  glob?: string,
+  test?: (file: string) => boolean
+) => {
+  const result = await globby(glob || '**/*', {
+    expandDirectories: true,
+    gitignore: true,
+  });
+  return test ? result.filter(s => test(s)) : result;
 };

--- a/src/utils/find-files.test.js
+++ b/src/utils/find-files.test.js
@@ -25,7 +25,7 @@ THE SOFTWARE.
 import {findFiles} from './find-files.js';
 
 test('findFiles', async () => {
-  const files = await findFiles('src', f => {
+  const files = await findFiles('src/**/*', f => {
     return /find-files.test.js/.test(f);
   });
   expect(files.length).toEqual(1);

--- a/src/utils/with-js-files.js
+++ b/src/utils/with-js-files.js
@@ -26,12 +26,8 @@ import {findFiles} from './find-files.js';
 import {withJsFile} from './with-js-file.js';
 import type {JsFileMutation} from './with-js-file.js';
 
-export const withJsFiles = async (
-  root: string,
-  regexp: RegExp,
-  fn: JsFileMutation
-) => {
-  const files = await findFiles(root, f => regexp.test(f));
+export const withJsFiles = async (glob: string, fn: JsFileMutation) => {
+  const files = await findFiles(glob);
   for (const file of files) {
     await withJsFile(file, fn);
   }

--- a/src/utils/with-js-files.test.js
+++ b/src/utils/with-js-files.test.js
@@ -30,7 +30,7 @@ test('withJsFiles', async () => {
   const fn = jest.fn();
   const file = '__sugared__/tmp.js';
   await writeFile(file, 'a');
-  await withJsFiles('__sugared__', /tmp.js/, fn);
+  await withJsFiles('__sugared__/tmp.js', fn);
   expect(fn.mock.calls[0][0].node.type).toBe('Program');
   await fse.remove('__sugared__');
 });


### PR DESCRIPTION
This pattern is much easier to work with, and is closer to the
defaults that generally make sense for most projects. This is a
breaking change.