### PR TITLE
Fix replaceJs almost always returning false

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ withJsFiles = (glob: string, fn: JsFileMutation) => Promise<void>;
 type JsFileMutation = NodePath => void;
 ```
 
-Runs `withJsFile` only on files that match `glob`. 
+Runs `withJsFile` only on files that match `glob`.
 
 See the [Babel handbook](https://github.com/jamiebuilds/babel-handbook/blob/master/translations/en/plugin-handbook.md) for more information on `NodePath`'s API.
 
@@ -411,7 +411,7 @@ A `NodePath` can be obtained from `withJsFile`, `withJsFiles` or `parseJs`.
 ```js
 import {replaceJs} from '@dubstep/core';
 
-replaceJs = (path: NodePath, source: string, target: string, wildcards: Array<string>) => void;
+replaceJs = (path: NodePath, source: string, target: string, wildcards: Array<string>) => boolean;
 ```
 
 Replaces code matching `source` with the code in `target`, transferring expressions contained in the `wildcards` list. Note that `path` should be a NodePath to a Program node.

--- a/src/utils/replace-js.js
+++ b/src/utils/replace-js.js
@@ -41,6 +41,7 @@ export const replaceJs = (
   const spreads = {};
   const interpolations = {};
   for (const name of wildcards) interpolations[name] = null;
+  let nodeReplaced = false;
   path.traverse({
     [node.type](path) {
       if (matched.get(node)) return; //prevent traversal if replaced with same code
@@ -54,9 +55,11 @@ export const replaceJs = (
           for (const statement of transformed) {
             if (match(node, statement)) matched.set(node, true);
           }
+          nodeReplaced = true;
           path.replaceWithMultiple(transformed);
         } else {
           if (match(node, transformed)) matched.set(node, true);
+          nodeReplaced = true;
           path.replaceWith(transformed);
         }
       }
@@ -73,7 +76,7 @@ export const replaceJs = (
       }
     },
   });
-  return matched.size > 0 || spreadReplaced;
+  return nodeReplaced || spreadReplaced;
 };
 
 function match(a, b, interpolations = {}, spreads = {}) {

--- a/src/utils/replace-js.test.js
+++ b/src/utils/replace-js.test.js
@@ -28,35 +28,52 @@ import {generateJs} from './generate-js.js';
 
 test('replaceJs', () => {
   const path = parseJs('const a = b * c + d;');
-  replaceJs(path, `b * $VALUE`, `x || $VALUE`, ['$VALUE']);
+  const result = replaceJs(path, `b * $VALUE`, `x || $VALUE`, ['$VALUE']);
   const generated = generateJs(path);
   expect(generated.trim()).toEqual('const a = (x || c) + d;');
+  expect(result).toBeTruthy();
 });
 
 test('replace varargs', () => {
   const path = parseJs('foo.bar(1, 2, 3);');
-  replaceJs(path, `foo.bar(...$ARGS)`, `fooBar(...$ARGS)`, ['$ARGS']);
+  const result = replaceJs(path, `foo.bar(...$ARGS)`, `fooBar(...$ARGS)`, [
+    '$ARGS',
+  ]);
   const generated = generateJs(path);
   expect(generated.trim()).toEqual('fooBar(1, 2, 3);');
+  expect(result).toBeTruthy();
 });
 
 test('multiple statements with wildcard', () => {
   const path = parseJs('const a = f(1);');
-  replaceJs(path, `const a = f(X)`, `const a = f(X);const b = 2;`, ['X']);
+  const result = replaceJs(
+    path,
+    `const a = f(X)`,
+    `const a = f(X);const b = 2;`,
+    ['X']
+  );
   const generated = generateJs(path);
   expect(generated.trim()).toEqual('const a = f(1);\nconst b = 2;');
+  expect(result).toBeTruthy();
 });
 
 test('multiple statements with spread wildcard', () => {
   const path = parseJs('const a = f(1, 2);');
-  replaceJs(path, `const a = f(...X)`, `const a = f(...X);const b = 2;`, ['X']);
+  const result = replaceJs(
+    path,
+    `const a = f(...X)`,
+    `const a = f(...X);const b = 2;`,
+    ['X']
+  );
   const generated = generateJs(path);
   expect(generated.trim()).toEqual('const a = f(1, 2);\nconst b = 2;');
+  expect(result).toBeTruthy();
 });
 
 test('ignore superset', () => {
   const path = parseJs('const a = XXX * c + d;');
-  replaceJs(path, `XXX * X`, `XXX || X`, ['X']);
+  const result = replaceJs(path, `XXX * X`, `XXX || X`, ['X']);
   const generated = generateJs(path);
   expect(generated.trim()).toEqual('const a = (XXX || c) + d;');
+  expect(result).toBeTruthy();
 });


### PR DESCRIPTION
A previous refactor added in a boolean return value for many of the file mutation methods.

For `replaceJs`, this method was almost always returning false. The refactor was using the existence of nodes being added to `matched` to determine if an actual replacement occurred. I don't 100% understand what `matched` is trying to do but it looks like it's preventing unneeded substitutions from occurring.

There doesn't seem to be a good way to determine if an actual node replacement successfully occurred since `NodePath.replaceWith` doesn't return anything useful. But if the code actually runs without hitting an exception then it's probably safe to assume that some replacement occurred.

The current test suite was failing all cases where actual replacements were being done but the method was still returning false. So I updated the test case to actually catch this.