### PR TITLE
Fix APIs which take BabelPath types as arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@babel/template": "^7.1.2",
     "@babel/traverse": "^7.1.5",
     "@babel/types": "^7.1.5",
-    "@ganemone/babel-flow-types": "^2.0.1",
+    "@ganemone/babel-flow-types": "^2.0.2",
     "execa": "^1.0.0",
     "flow-coverage-report": "^0.6.0",
     "fs-extra": "^7.0.1",

--- a/src/utils/generate-js.js
+++ b/src/utils/generate-js.js
@@ -23,8 +23,8 @@ THE SOFTWARE.
 */
 
 import recast from 'recast';
-import type {BabelPath, Node} from '@ganemone/babel-flow-types';
+import type {BabelPath} from '@ganemone/babel-flow-types';
 
-export const generateJs = (path: BabelPath<Node>) => {
+export const generateJs = (path: BabelPath<any>) => {
   return recast.print(path.parent).code;
 };

--- a/src/utils/insert-js-after.js
+++ b/src/utils/insert-js-after.js
@@ -23,10 +23,10 @@ THE SOFTWARE.
 */
 
 import {replaceJs} from './replace-js.js';
-import type {BabelPath, Node} from '@ganemone/babel-flow-types';
+import type {BabelPath} from '@ganemone/babel-flow-types';
 
 export const insertJsAfter = (
-  path: BabelPath<Node>,
+  path: BabelPath<any>,
   target: string,
   code: string,
   wildcards: Array<string> = []

--- a/src/utils/insert-js-before.js
+++ b/src/utils/insert-js-before.js
@@ -23,10 +23,10 @@ THE SOFTWARE.
 */
 
 import {replaceJs} from './replace-js.js';
-import type {BabelPath, Node} from '@ganemone/babel-flow-types';
+import type {BabelPath} from '@ganemone/babel-flow-types';
 
 export const insertJsBefore = (
-  path: BabelPath<Node>,
+  path: BabelPath<any>,
   target: string,
   code: string,
   wildcards: Array<string> = []

--- a/src/utils/parse-js.js
+++ b/src/utils/parse-js.js
@@ -26,14 +26,18 @@ import traverse from '@babel/traverse';
 import NodePath from '@babel/traverse/lib/path';
 import {parse} from '@babel/parser';
 import recast from 'recast';
+import type {Node, BabelPath, Program} from '@ganemone/babel-flow-types';
 
 export type ParserOptions = ?{mode: ?('typescript' | 'flow')};
 
-export const parseStatement = (code: string, options: ParserOptions) => {
+export const parseStatement = (code: string, options: ParserOptions): Node => {
   return parseJs(code, options).node.body[0];
 };
 
-export const parseJs = (code: string, options: ParserOptions) => {
+export const parseJs = (
+  code: string,
+  options: ParserOptions
+): BabelPath<Program> => {
   const typeSystem =
     options && options.mode === 'typescript'
       ? ['typescript']

--- a/src/utils/remove-js-imports.js
+++ b/src/utils/remove-js-imports.js
@@ -23,9 +23,12 @@ THE SOFTWARE.
 */
 
 import {parseJs} from './parse-js.js';
-import type {BabelPath, Node} from '@ganemone/babel-flow-types';
+import type {BabelPath, Program} from '@ganemone/babel-flow-types';
 
-export const removeJsImports = (path: BabelPath<Node>, code: string): void => {
+export const removeJsImports = (
+  path: BabelPath<Program>,
+  code: string
+): void => {
   parseJs(code).traverse({
     ImportDeclaration(obsoletePath) {
       path.traverse({
@@ -64,7 +67,8 @@ function remove(path, name) {
     const refPaths = binding.referencePaths;
     for (const refPath of refPaths) {
       if (refPath.type !== 'ImportDeclaration') {
-        refPath.getStatementParent().remove();
+        const parent = refPath.getStatementParent();
+        parent && parent.remove();
       }
     }
   }

--- a/src/utils/replace-js.js
+++ b/src/utils/replace-js.js
@@ -24,10 +24,10 @@ THE SOFTWARE.
 
 import template from '@babel/template';
 import {parseJs} from './parse-js.js';
-import type {BabelPath, Node} from '@ganemone/babel-flow-types';
+import type {BabelPath} from '@ganemone/babel-flow-types';
 
 export const replaceJs = (
-  path: BabelPath<Node>,
+  path: BabelPath<any>,
   source: string,
   target: string,
   wildcards: Array<string> = []
@@ -76,6 +76,7 @@ export const replaceJs = (
 
 function match(a, b, interpolations = {}, spreads = {}) {
   if (isInterpolation(b, interpolations)) {
+    // $FlowFixMe
     interpolations[b.name] = a;
     return true;
   }
@@ -124,6 +125,7 @@ function isNode(node) {
 function isEquivalentJSXText(a, b, key) {
   // JSX text node might have different values depending on indentation
   return (
+    // $FlowFixMe
     a.type === 'JSXText' && key === 'value' && a.value.trim() === b.value.trim()
   );
 }

--- a/src/utils/visit-js-import.js
+++ b/src/utils/visit-js-import.js
@@ -29,13 +29,13 @@ import {
 } from '@babel/types';
 import type {
   BabelPath,
-  Node,
+  Program,
   ImportDeclaration,
   Identifier,
 } from '@ganemone/babel-flow-types';
 
 export const visitJsImport = (
-  path: BabelPath<Node>,
+  path: BabelPath<Program>,
   source: string,
   handler: (
     path: BabelPath<ImportDeclaration>,

--- a/src/utils/visit-js-import.test.js
+++ b/src/utils/visit-js-import.test.js
@@ -108,5 +108,5 @@ test('visitJsImport validation', () => {
   expect(() => {
     visitJsImport(path, `import {a, b} from 'c'`, handler);
   }).toThrow();
-  expect(handler).not.toBeCalled();
+  expect(handler).not.toHaveBeenCalled();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -222,10 +222,10 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@ganemone/babel-flow-types@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@ganemone/babel-flow-types/-/babel-flow-types-2.0.1.tgz#4433fd58c86a3ed97e518a1121df44e45ea36eda"
-  integrity sha512-H4cQsAjy73+W3qwqhvI4GhIAjkV1MRlFsfnw9WdTNAVUEp09cqDpfAgI235uWIl9FmBPSh1cneyU3qV39GjPZw==
+"@ganemone/babel-flow-types@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@ganemone/babel-flow-types/-/babel-flow-types-2.0.2.tgz#8aa5ad991597db7481b139f8cc0a0a09649f8698"
+  integrity sha512-bTxh+DdtzxojUqBtlyX0u8s8zXWjVlRZ9CzSJcM4XhX6JRRWMWyWIsEWzw7v0El3Cv2bOVbI7zIsHN2K05X0sA==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"


### PR DESCRIPTION
There is an issue with flow and disjoint unions when used
as object properties. The main benefit of thse types is with
the return values so we still get benefits despite using any
in a few places.