### PR TITLE
Include file as second argument to the JsFileMutation type

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ If the file does not exist, `fn` is called with an empty array, and the file is 
 import {withJsFile} from '@dubstep/core';
 
 type withJsFile = (file: string, fn: JsFileMutation) => Promise<any>;
-type JsFileMutation = BabelPath => Promise<any>;
+type JsFileMutation = (program: BabelPath, file: string) => Promise<any>;
 ```
 
 Opens a file, parses each line into a Babel BabelPath, and calls `fn` with BabelPath. Then, writes the modified AST back into the file.
@@ -197,7 +197,7 @@ See the [Babel handbook](https://github.com/jamiebuilds/babel-handbook/blob/mast
 import {withJsFiles} from '@dubstep/core';
 
 type withJsFiles = (glob: string, fn: JsFileMutation) => Promise<any>;
-type JsFileMutation = BabelPath => Promise<any>;
+type JsFileMutation = (program: BabelPath, file: string) => Promise<any>;
 ```
 
 Runs `withJsFile` only on files that match `glob`.

--- a/src/utils/with-js-file.js
+++ b/src/utils/with-js-file.js
@@ -28,13 +28,13 @@ import {parseJs} from './parse-js.js';
 import {generateJs} from './generate-js.js';
 import type {BabelPath, Program} from '@ganemone/babel-flow-types';
 
-export type JsFileMutation = (BabelPath<Program>) => Promise<any>;
+export type JsFileMutation = (BabelPath<Program>, file: string) => Promise<any>;
 
 export const withJsFile = async (file: string, transform: JsFileMutation) => {
   const code = await readFile(file).catch(() => '');
   try {
     const program = parseJs(code);
-    await transform(program);
+    await transform(program, file);
     const generated = generateJs(program);
     await writeFile(file, generated);
   } catch (e) {

--- a/src/utils/with-js-file.test.js
+++ b/src/utils/with-js-file.test.js
@@ -32,5 +32,6 @@ test('withJsFile', async () => {
   await writeFile(file, 'a');
   await withJsFile(file, fn);
   expect(fn.mock.calls[0][0].type).toBe('Program');
+  expect(fn.mock.calls[0][1]).toBe('__js__.js');
   await remove(file);
 });

--- a/src/utils/with-js-files.test.js
+++ b/src/utils/with-js-files.test.js
@@ -32,5 +32,6 @@ test('withJsFiles', async () => {
   await writeFile(file, 'a');
   await withJsFiles('__sugared__/tmp.js', fn);
   expect(fn.mock.calls[0][0].type).toBe('Program');
+  expect(fn.mock.calls[0][1]).toBe('__sugared__/tmp.js');
   await remove('__sugared__');
 });


### PR DESCRIPTION
This is especially useful when dealing with the `withJsFiles`
utility and working with logic that depends on the current
file location, such as moving around imports.