### PR TITLE
Handle importKind in ensureJsImport utility

### DIFF
--- a/src/utils/ensure-js-imports.js
+++ b/src/utils/ensure-js-imports.js
@@ -39,7 +39,10 @@ export const ensureJsImports = (path: BabelPath<Program>, code: string) => {
         ImportDeclaration(path) {
           const specifiers = path.node.specifiers;
           const newSpecifiers = newPath.node.specifiers;
-          if (path.node.source.value === newPath.node.source.value) {
+          if (
+            path.node.source.value === newPath.node.source.value &&
+            path.node.importKind === newPath.node.importKind
+          ) {
             matched = true;
             // add default specifier if it's missing
             const pathHasDefault = hasDefaultSpecifier(path.node);

--- a/src/utils/ensure-js-imports.test.js
+++ b/src/utils/ensure-js-imports.test.js
@@ -87,7 +87,7 @@ test('multiple', () => {
 });
 
 test('type imports', () => {
-  const path = parseJs(`import A from 'A'`);
+  const path = parseJs(`import A from 'A';`);
   ensureJsImports(
     path,
     `
@@ -96,12 +96,12 @@ test('type imports', () => {
   );
   const code = generateJs(path);
   expect(code.trim()).toMatchInlineSnapshot(
-    `"import A from 'A'import type {B} from 'A';"`
+    `"import A from 'A';import type {B} from 'A';"`
   );
 });
 
 test('ensuring type imports', () => {
-  const path = parseJs(`import type {A} from 'A'`);
+  const path = parseJs(`import type {A} from 'A';`);
   ensureJsImports(
     path,
     `
@@ -113,7 +113,7 @@ test('ensuring type imports', () => {
 });
 
 test('mixing type and regular importKind', () => {
-  const path = parseJs(`import A, {type B, C} from 'A'`);
+  const path = parseJs(`import A, {type B, C} from 'A';`);
   ensureJsImports(
     path,
     `

--- a/src/utils/ensure-js-imports.test.js
+++ b/src/utils/ensure-js-imports.test.js
@@ -85,3 +85,43 @@ test('multiple', () => {
   );
   expect(vars).toEqual([{default: 'foo'}, {default: 'bar', x: 'x'}]);
 });
+
+test('type imports', () => {
+  const path = parseJs(`import A from 'A'`);
+  ensureJsImports(
+    path,
+    `
+    import type {B} from 'A';
+    `
+  );
+  const code = generateJs(path);
+  expect(code.trim()).toMatchInlineSnapshot(
+    `"import A from 'A'import type {B} from 'A';"`
+  );
+});
+
+test('ensuring type imports', () => {
+  const path = parseJs(`import type {A} from 'A'`);
+  ensureJsImports(
+    path,
+    `
+    import type {B} from 'A';
+    `
+  );
+  const code = generateJs(path);
+  expect(code.trim()).toMatchInlineSnapshot(`"import type { A, B } from 'A';"`);
+});
+
+test('mixing type and regular importKind', () => {
+  const path = parseJs(`import A, {type B, C} from 'A'`);
+  ensureJsImports(
+    path,
+    `
+    import {D, type E} from 'A';
+    `
+  );
+  const code = generateJs(path);
+  expect(code.trim()).toMatchInlineSnapshot(
+    `"import A, { type B, C, D, type E } from 'A';"`
+  );
+});


### PR DESCRIPTION
This ensures the ability to handle regular and type imports
when using the ensureJsImport utility and adds regression tests.