### PR TITLE
Upgrade and re-export types from @ganemone/babel-flow-types

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,17 @@ foo.bar(1, 2, 3); // before
 transformed(1, 2, 3); // after
 ```
 
+##### t
+
+```js
+import {t} from '@dubstep/core';
+
+t.arrayExpression([]);
+// etc.
+```
+
+This is a flow-typed version of the exports from `@babel/types`. It is useful for creating AST nodes and asserting on existing AST nodes.
+
 ---
 
 #### Git

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@babel/template": "^7.1.2",
     "@babel/traverse": "^7.1.5",
     "@babel/types": "^7.1.5",
-    "@ganemone/babel-flow-types": "^2.0.6",
+    "@ganemone/babel-flow-types": "^2.0.7",
     "execa": "^1.0.0",
     "flow-coverage-report": "^0.6.0",
     "fs-extra": "^7.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,11 @@ THE SOFTWARE.
 @flow
 */
 
+import * as types from '@babel/types';
+import {type Types} from '@ganemone/babel-flow-types';
+
+export const t: Types = types;
+
 export * from './step.js';
 export * from './types.js';
 export * from './utils/create-restore-point.js';
@@ -48,3 +53,4 @@ export * from './utils/write-file.js';
 export * from './utils/with-js-files.js';
 export * from './utils/visit-js-import.js';
 export * from './utils/collapse-imports.js';
+export * from '@ganemone/babel-flow-types';

--- a/src/utils/remove-js-imports.js
+++ b/src/utils/remove-js-imports.js
@@ -42,6 +42,7 @@ export const removeJsImports = (
               });
               if (specifier.type === 'ImportSpecifier') {
                 const name = specifier.imported.name;
+                // $FlowFixMe
                 const match = ofSameType.find(s => name === s.imported.name);
                 if (match) remove(path, localName);
                 return !match;

--- a/yarn.lock
+++ b/yarn.lock
@@ -222,10 +222,10 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@ganemone/babel-flow-types@^2.0.6":
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/@ganemone/babel-flow-types/-/babel-flow-types-2.0.6.tgz#adda45cca61814c44171382caab3fbb4357e2da8"
-  integrity sha512-KVkFzjXdaaPQ7nj0oz5ysjgRD/L83l2vVkxYlQaJPWB3bIHuxTT6Y1EdbMu343gXhsAng+WMRY0DTUczxzjt5w==
+"@ganemone/babel-flow-types@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@ganemone/babel-flow-types/-/babel-flow-types-2.0.7.tgz#a8d65b73344717493e09cc4e3b25f3b5a9420460"
+  integrity sha512-bLyU6dJuiPe5v/1Ykz+j9OCmKKhzRSVOCxhXgtw3qK0JKnZh/6ti2i2CNeSwsd+GoHfQSWmW69pPr8ZMjdDPwA==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"


### PR DESCRIPTION
This improves the types for Path.traverse as well as exporting a 
typed object of ast node constructors